### PR TITLE
Tomcat 서버를 하나 더 추가하고 크로스 도메인을 실습

### DIFF
--- a/AjaxPractice/WebContent/Chapter3/cross.jsp
+++ b/AjaxPractice/WebContent/Chapter3/cross.jsp
@@ -1,0 +1,18 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>cross 실습</title>
+</head>
+<body>
+	<%
+	// 크로스 도메인 요청을 허용하기 위하여 Access-Control-Allow-Origin 헤더에 *값을 설정함 
+	// 서로 다른 모든 도메인에서 요청이 허용됨 
+	// 해당 코드를 지우면 'No Access-Control-Allow-Origin'에러가 발생함 
+	response.setHeader("Access-Control-Allow-Origin", "*");
+	out.print("Hello World");
+	%>
+</body>
+</html>

--- a/AjaxPractice/WebContent/Chapter3/sample03_7.html
+++ b/AjaxPractice/WebContent/Chapter3/sample03_7.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Cross Domain 실습</title>
+<script type="text/javascript">
+	var xhttp;
+	
+	function createHttpRequest() {
+		xhttp = new XMLHttpRequest();
+	}
+	
+	function mySend() {
+		createHttpRequest();
+		xhttp.onreadystatechange = callFunction;
+		// 크로스 도메인 요청을 위하여 port번호가 9000인 Tomcat서버에 cross.jsp를 요청함 
+		xhttp.open("GET", "http://localhost:9000/AjaxPractice/Chapter3/cross.jsp", true);
+		xhttp.send(null);
+	}
+	
+	function callFunction() {
+		if(xhttp.readyState == 4) {
+			if(xhttp.status == 200) {
+				var responseData = xhttp.responseText;
+				document.getElementById("result").innerHTML = responseData;
+			}
+		}
+	}
+</script>
+</head>
+<body>
+	CORS 파일 실습입니다 <br>
+	<button onclick="mySend()">CROSS 파일 수신</button>
+	<div id="result"></div>
+</body>
+</html>


### PR DESCRIPTION
같은 IP라도 port번호가 다르면 다른 도메인이라고 인식하게 됨
주의할 점은 Tomcat admin port와 AJP/1.3포트 번호도 다르게 설정해야 함